### PR TITLE
Removed required argument from styles()

### DIFF
--- a/src/Roumen/Asset/Asset.php
+++ b/src/Roumen/Asset/Asset.php
@@ -158,7 +158,7 @@ class Asset
      *
      * @return void
     */
-    public static function styles($s)
+    public static function styles()
     {
         if (!empty(self::$styles))
         {


### PR DESCRIPTION
Unused required argument throws missing argument error from code example.

Issue: https://github.com/RoumenDamianoff/laravel4-assets/issues/1
