### PR TITLE
checkEnv will not attempt to set default domain if it is set to custom d...

### DIFF
--- a/src/Roumen/Asset/Asset.php
+++ b/src/Roumen/Asset/Asset.php
@@ -27,7 +27,7 @@ class Asset
     {
         $env = \App::environment();
 
-        if ($env == 'local' || $env == 'testing')
+        if (($env == 'local' || $env == 'testing') && (self::$domain === '/'))
         {
             self::$domain = '/';
         }


### PR DESCRIPTION
...omain

Currently checkEnv will always default domain to / on local no matter the domain you set it to.
