### PR TITLE
New methods: setCachebuster(), jsRaw() and cssRaw()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,18 @@ Asset::add('js/some.js', 'footer');
 $script1 = '$("#hello").html("Hello World!")';
 Asset::addScript($script1, 'ready');
 
-// loads css assets (place this in your master layout before close head tag)
+// loads css assets (place this in your master layout before close head tag) wrapped in <link> tags
 Asset::css();
 
-// loads js assets for your header and footer
+// loads css assets (place this in your master layout before close head tag) not wrapped in <link> tags and joined using a custom separator
+Asset::cssRaw('\n');
+
+// loads js assets for your header and footer wrapped in <script> tags
 Asset::js();
 Asset::js('header');
+
+// loads js assets for your header and footer not wrapped in <script> tags and joined using a custom separator
+Asset::jsRaw('\n');
 
 // loads all scripts for your header, footer or for your $(document).ready() function
 Asset::scripts('header');
@@ -98,6 +104,8 @@ Asset::setCachebuster(public_path() . '/build/assets.json');
 </html>
 ```
 ## Changelog
+
+v2.1 - Added setCachebuster(), jsRaw() and cssRaw() methods
 
 v2.0 - Added setPrefix() method
 

--- a/src/Roumen/Asset/Asset.php
+++ b/src/Roumen/Asset/Asset.php
@@ -37,6 +37,8 @@ class Asset
     /**
      * Set domain name
      *
+     * @param string $url
+     *
      * @return void
     */
     public static function setDomain($url)
@@ -47,6 +49,8 @@ class Asset
     /**
      * Set prefix
      *
+     * @param string $prefix
+     *
      * @return void
     */
     public static function setPrefix($prefix)
@@ -56,6 +60,8 @@ class Asset
 
     /**
      * Set cache buster JSON file
+     *
+     * @param string $cachebuster
      *
      * @return void
     */
@@ -112,7 +118,7 @@ class Asset
                 array_unshift(self::$js[$name], $a);
             } else
                 {
-                    self::$js[$name][] = $a;
+                    self::$js[$name][] = property_exists(self::$hash, $a) ? $a . "?" . self::$hash->{$a} : $a;
                 }
         }
     }
@@ -135,6 +141,7 @@ class Asset
     /**
      * Add new style
      *
+     * @param string $style
      * @param string $s
      *
      * @return void
@@ -144,6 +151,33 @@ class Asset
         self::$styles[$s][] = $style;
     }
 
+
+    /**
+     * Loads all items from $css array not wrapped in <link> tags
+     *
+     * @param string $separator
+     *
+     * @return void
+    */
+    public static function cssRaw($separator = "")
+    {
+        self::checkEnv();
+
+        if (!empty(self::$css))
+        {
+            foreach(self::$css as $file)
+            {
+                if (preg_match('/(https?:)?\/\//i', $file))
+                {
+                    $url = $file;
+                } else
+                    {
+                        $url = self::$domain . $file;
+                    }
+                echo self::$prefix . $url . $separator;
+            }
+        }
+    }
 
     /**
      * Loads all items from $css array
@@ -204,9 +238,40 @@ class Asset
 
 
     /**
+     * Loads items from $js array not wrapped in <script> tags
+     *
+     * @param string $separator
+     * @param string $name
+     *
+     * @return void
+    */
+    public static function jsRaw($separator = "", $name = 'footer')
+    {
+        self::checkEnv();
+
+        if (!empty(self::$js[$name]))
+        {
+            foreach(self::$js[$name] as $file)
+            {
+                if (preg_match('/(https?:)?\/\//i', $file))
+                {
+                    $url = $file;
+                } else
+                    {
+                       $url = self::$domain . $file;
+                    }
+                echo self::$prefix . $url . $separator;
+            }
+        }
+
+    }
+
+    /**
      * Loads items from $js array
      *
      * @param string $name
+     * @param boolean $tags
+     * @param string $join
      *
      * @return void
     */
@@ -214,6 +279,7 @@ class Asset
     {
         self::checkEnv();
 
+        if ($name === false) $name = 'footer';
         if (!empty(self::$js[$name]))
         {
             foreach(self::$js[$name] as $file)
@@ -230,7 +296,6 @@ class Asset
         }
 
     }
-
 
     /**
      * Loads items from $scripts array


### PR DESCRIPTION
`setCachebuster` is for Grunt and similar task runners that can generate a JSON map file with hashes of compiled assets. Once set, all matched asset URLs will be appended with a `?hash` string.

`jsRaw()` and `cssRaw()` methods enable raw output without being wrapped in `<script>` and `<link` tags, respectively. Useful, for example, if you wish to load a single minified script using Google's suggested method:

```
<script>
function run() {
    var a = document.createElement("script");
    a.src ="{{ Asset::jsRaw() }}", document.body.appendChild(a)
}
window.addEventListener ? window.addEventListener("load", run, !1) : window.attachEvent ? window.attachEvent("onload", run) : window.onload = run;
</script>
```
