### PR TITLE
Varius Modifications to Asset.php

### DIFF
--- a/src/Roumen/Asset/Asset.php
+++ b/src/Roumen/Asset/Asset.php
@@ -4,12 +4,29 @@
  * Asset class for laravel-assets package.
  *
  * @author Roumen Damianoff <roumen@dawebs.com>
- * @version 2.3.12
+ * @version 2.3.13
  * @link http://roumen.it/projects/laravel-assets
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
 class Asset
 {
+    // This constant indicates where to add a asset;
+    const ADD_TO_NONE    = 0;
+    const ADD_TO_CSS     = 1;
+    const ADD_TO_LESS    = 2;
+    const ADD_TO_JS      = 3;
+
+    /*
+     * If the assert To add do not have extension or the extension
+     * is unknown this constant indicate what to do:
+     */
+    const ON_UNKNOWN_EXTENSION_NONE                  = 0;
+    const ON_UNKNOWN_EXTENSION_CSS                   = 1;
+    const ON_UNKNOWN_EXTENSION_LESS                  = 2;
+    const ON_UNKNOWN_EXTENSION_JS                    = 3;
+    private static $ON_UNKNOWN_EXTENSION_TO_ADD_TO   = array(Asset::ON_UNKNOWN_EXTENSION_NONE    => Asset::ADD_TO_CSS,
+                                                             Asset::ON_UNKNOWN_EXTENSION_LESS    => Asset::ADD_TO_LESS,
+                                                             Asset::ON_UNKNOWN_EXTENSION_JS      => Asset::ADD_TO_JS);
 
     public static $css = array();
     public static $less = array();
@@ -21,6 +38,8 @@ class Asset
     public static $hash = null;
     public static $environment = null;
     protected static $cacheBusterGeneratorFunction = null;
+    private static $useShortHandReady = false;
+    private static $onUnknownExtensionDefault = Asset::ON_UNKNOWN_EXTENSION_NONE;
 
     /**
      * Check environment
@@ -29,14 +48,11 @@ class Asset
     */
     public static function checkEnv()
     {
-        if (static::$environment == null)
-        {
+        if (static::$environment == null) {
             static::$environment = \App::environment();
         }
-
         // use only local files in local environment
-        if (static::$environment == 'local' && static::$domain != '/')
-        {
+        if (static::$environment == 'local' && (static::$domain != '/')) {
             static::$domain = '/';
         }
     }
@@ -50,7 +66,9 @@ class Asset
     */
     public static function setDomain($url)
     {
-        static::$domain = $url;
+        if (is_string($url)) {
+            static::$domain = $url;
+        }
     }
 
     /**
@@ -74,7 +92,9 @@ class Asset
     */
     public static function setCachebuster($cachebuster)
     {
-        if (file_exists($cachebuster)) static::$hash = json_decode(file_get_contents($cachebuster));
+        if (file_exists($cachebuster)) {
+            static::$hash = json_decode(file_get_contents($cachebuster));
+        }
     }
 
     /**
@@ -102,11 +122,41 @@ class Asset
     */
     private static function generateCacheBusterFilename($a)
     {
-        if(!static::$cacheBusterGeneratorFunction instanceof \Closure){
+        if(!static::$cacheBusterGeneratorFunction instanceof \Closure) {
             return (static::$hash && property_exists(static::$hash, $a)) ? static::$hash->{$a} : $a;
-        }else{
+        } else {
             return static::$cacheBusterGeneratorFunction($a);
         }
+    }
+
+    /**
+     * Set indicator if use Short Hand [$()] or Normal $( document ).ready()
+     *
+     * @param boolean $useShortHandReady
+     *
+     * @return void
+    */
+    public static function setUseShortHandReady($useShortHandReady)
+    {
+        static::$useShortHandReady = $useShortHandReady;
+    }
+
+    /**
+     * Indicate what to do by default if an unknown extension is found.
+     *
+     * @param int (self::ON_UNKNOWN_EXTENSION_NONE,
+     *             self::ON_UNKNOWN_EXTENSION_JS) $onUnknownExtensionDefault
+     *
+     * @return void
+    */
+    public static function setOnUnknownExtensionDefault($onUnknownExtensionDefault)
+    {
+        if ((!is_int($onUnknownExtensionDefault))
+            || ($onUnknownExtensionDefault < self::ON_UNKNOWN_EXTENSION_NONE)
+            || ($onUnknownExtensionDefault > self::ON_UNKNOWN_EXTENSION_JS)) {
+            $onUnknownExtensionDefault = self::ON_UNKNOWN_EXTENSION_NONE;
+        }
+        static::$onUnknownExtensionDefault = $onUnknownExtensionDefault;
     }
 
     /**
@@ -114,15 +164,50 @@ class Asset
      *
      * @param string $a
      * @param string $name
+     * @param int (self::ON_UNKNOWN_EXTENSION_NONE,
+     *             self::ON_UNKNOWN_EXTENSION_JS) $onUnknownExtension
      *
      * @return void
     */
-    public static function add($a, $name = 'footer')
+    public static function add($a, $name = 'footer', $onUnknownExtension = false)
     {
-        if (is_array($a))
-            foreach ($a as $item) static::processAdd($item, $name);
-        else
-            static::processAdd($a, $name);
+        if (is_array($a)) {
+            foreach ($a as $item) {
+                static::processAdd($item, $name, $onUnknownExtension);
+            }
+        } else {
+            static::processAdd($a, $name, $onUnknownExtension);
+        }
+    }
+
+    /**
+     * Identify where to add an asset:
+     *
+     * @param string $a
+     * @param int (self::ON_UNKNOWN_EXTENSION_NONE,
+     *             self::ON_UNKNOWN_EXTENSION_JS)/boolean $onUnknownExtension
+     *
+     * @return int (self::ADD_TO_NONE, self::ADD_TO_JS)
+    */
+    private static function getAddTo($a, $onUnknownExtension = false)
+    {
+        if (false === $onUnknownExtension) {
+        	$onUnknownExtension = static::$onUnknownExtensionDefault;
+        }
+        if (preg_match("/(\.css|\/css\?)/i", $a)) {
+        	// css
+        	return self::ADD_TO_CSS;
+        } elseif (preg_match("/\.less/i", $a)) {
+        	// less
+        	return self::ADD_TO_LESS;
+        } elseif (preg_match("/\.js|\/js/i", $a)) {
+        	// js
+        	return self::ADD_TO_JS;
+        } elseif ((self::ON_UNKNOWN_EXTENSION_NONE != $onUnknownExtension)
+        		&& isset(self::$ON_UNKNOWN_EXTENSION_TO_ADD_TO[$onUnknownExtension])) {
+        	return self::$ON_UNKNOWN_EXTENSION_TO_ADD_TO[$onUnknownExtension];
+        }
+        return self::ADD_TO_NONE;
     }
 
     /**
@@ -133,26 +218,20 @@ class Asset
      *
      * @return void
     */
-    protected static function processAdd($a, $name)
+    protected static function processAdd($a, $name, $onUnknownExtension = false)
     {
         $a = static::generateCacheBusterFilename($a);
 
-        if (preg_match("/(\.css|\/css\?)/i", $a))
-        {
-            // css
-            static::$css[] = $a;
-        }
-
-        if (preg_match("/\.less/i", $a))
-        {
-            // less
-            static::$less[] = $a;
-        }
-
-        elseif (preg_match("/\.js/i", $a))
-        {
-            // js
-            static::$js[$name][] = $a;
+        switch (self::getAddTo($a, $onUnknownExtension)) {
+        	case self::ADD_TO_CSS:
+        		static::$css[] = $a;
+        		break;
+        	case self::ADD_TO_LESS:
+        		static::$less[] = $a;
+        		break;
+        	case self::ADD_TO_JS:
+        		static::$js[$name][] = $a;
+        		break;
         }
     }
 
@@ -164,32 +243,25 @@ class Asset
      *
      * @return void
     */
-    public static function addFirst($a, $name = 'footer')
+    public static function addFirst($a, $name = 'footer', $onUnknownExtension = false)
     {
         $a = static::generateCacheBusterFilename($a);
 
-        if (preg_match("/(\.css|\/css\?)/i", $a))
-        {
-            // css
-            array_unshift(static::$css, $a);
-        }
-
-        if (preg_match("/\.less/i", $a))
-        {
-            // less
-            array_unshift(static::$less, $a);
-        }
-
-        elseif (preg_match("/\.js/i", $a))
-        {
-            // js
-            if (!empty(static::$js[$name]))
-            {
-                array_unshift(static::$js[$name], $a);
-            } else
-                {
+        switch (self::getAddTo($a, $onUnknownExtension)) {
+        	case self::ADD_TO_CSS:
+        		array_unshift(static::$css, $a);
+        		break;
+        	case self::ADD_TO_LESS:
+        		array_unshift(static::$less, $a);
+        		break;
+        	case self::ADD_TO_JS:
+                if (!empty(static::$js[$name])) {
+                    array_unshift(static::$js[$name], $a);
+                } else {
                     static::$js[$name][] = $a;
                 }
+        	    array_unshift(static::$less, $a);
+        		break;
         }
     }
 
@@ -202,71 +274,52 @@ class Asset
      *
      * @return void
     */
-    public static function addBefore($a, $b, $name = 'footer')
+    public static function addBefore($a, $b, $name = 'footer', $onUnknownExtension = false)
     {
         $a = static::generateCacheBusterFilename($a);
 
-        if (preg_match("/(\.css|\/css\?)/i", $a))
-        {
-            // css
-            $bpos = array_search($b, static::$css);
-
-            if ($bpos === 0)
-            {
-                static::addFirst($a, $name);
-            } elseif ($bpos >= 1)
-                {
+        switch (self::getAddTo($a, $onUnknownExtension)) {
+        	case self::ADD_TO_CSS:
+                $bpos = array_search($b, static::$css);
+                if ($bpos === 0) {
+                    static::addFirst($a, $name);
+                } elseif ($bpos >= 1) {
                     $barr = array_slice(static::$css, $bpos);
                     $aarr = array_slice(static::$css, 0, $bpos);
                     array_push($aarr, $a);
                     static::$css = array_merge($aarr, $barr);
-                } else
-                    {
-                        static::$css[] = $a;
-                    }
-        }
-
-        if (preg_match("/\.less/i", $a))
-        {
-            // less
-            $bpos = array_search($b, static::$less);
-
-            if ($bpos === 0)
-            {
-                static::addFirst($a, $name);
-            } elseif ($bpos >= 1)
-                {
+                } else {
+                    static::$css[] = $a;
+                }
+        		break;
+        	case self::ADD_TO_LESS:
+                $bpos = array_search($b, static::$less);
+                if ($bpos === 0) {
+                    static::addFirst($a, $name);
+                } elseif ($bpos >= 1) {
                     $barr = array_slice(static::$less, $bpos);
                     $aarr = array_slice(static::$less, 0, $bpos);
                     array_push($aarr, $a);
                     static::$less = array_merge($aarr, $barr);
-                } else
-                    {
-                        static::$less[] = $a;
-                    }
-        }
-
-        elseif (preg_match("/\.js/i", $a))
-        {
-            // js
-            if (!empty(static::$js[$name]))
-            {
-                $bpos = array_search($b, static::$js[$name]);
-
-                if ($bpos === 0)
-                {
-                    static::addFirst($a, $name);
-                } elseif ($bpos >= 1)
-                    {
+                } else {
+                    static::$less[] = $a;
+                }
+        		break;
+        	case self::ADD_TO_JS:
+                if (!empty(static::$js[$name])) {
+                    $bpos = array_search($b, static::$js[$name]);
+                    if ($bpos === 0) {
+                        static::addFirst($a, $name);
+                    } elseif ($bpos >= 1) {
                         $barr = array_slice(static::$js[$name], $bpos);
                         $aarr = array_slice(static::$js[$name], 0, $bpos);
                         array_push($aarr, $a);
                         static::$js[$name] = array_merge($aarr, $barr);
-                    } else
-                        {
-                            static::$js[$name][] = $a;
-                        }
-            }
+                    } else {
+                        static::$js[$name][] = $a;
+                    }
+                }
+                break;
         }
     }
 
@@ -279,62 +332,47 @@ class Asset
      *
      * @return void
     */
-    public static function addAfter($a, $b, $name = 'footer')
+    public static function addAfter($a, $b, $name = 'footer', $onUnknownExtension = false)
     {
         $a = static::generateCacheBusterFilename($a);
 
-        if (preg_match("/(\.css|\/css\?)/i", $a))
-        {
-            // css
-            $bpos = array_search($b, static::$css);
-
-            if ($bpos === 0 || $bpos > 0)
-            {
-                $barr = array_slice(static::$css, $bpos+1);
-                $aarr = array_slice(static::$css, 0, $bpos+1);
-                array_push($aarr, $a);
-                static::$css = array_merge($aarr, $barr);
-            } else
-                {
+            switch (self::getAddTo($a, $onUnknownExtension)) {
+        	case self::ADD_TO_CSS:
+                $bpos = array_search($b, static::$css);
+                if ($bpos === 0 || $bpos > 0) {
+                    $barr = array_slice(static::$css, $bpos+1);
+                    $aarr = array_slice(static::$css, 0, $bpos+1);
+                    array_push($aarr, $a);
+                    static::$css = array_merge($aarr, $barr);
+                } else {
                     static::$css[] = $a;
                 }
-        }
-
-        if (preg_match("/\.less/i", $a))
-        {
-            // less
-            $bpos = array_search($b, static::$less);
-
-            if ($bpos === 0 || $bpos > 0)
-            {
+        		break;
+        	case self::ADD_TO_LESS:
+                $bpos = array_search($b, static::$less);
+                if ($bpos === 0 || $bpos > 0) {
                     $barr = array_slice(static::$less, $bpos+1);
                     $aarr = array_slice(static::$less, 0, $bpos+1);
                     array_push($aarr, $a);
                     static::$less = array_merge($aarr, $barr);
-                } else
-                    {
-                        static::$less[] = $a;
-                    }
-        }
-
-        elseif (preg_match("/\.js/i", $a))
-        {
-            // js
-            if (!empty(static::$js[$name]))
-            {
-                $bpos = array_search($b, static::$js[$name]);
-
-                if ($bpos === 0 || $bpos > 0)
+                } else {
+                    static::$less[] = $a;
+                }
+        		break;
+        	case self::ADD_TO_JS:
+                if (!empty(static::$js[$name]))
                 {
-                    $barr = array_slice(static::$js[$name], $bpos+1);
-                    $aarr = array_slice(static::$js[$name], 0, $bpos+1);
-                    array_push($aarr, $a);
-                    static::$js[$name] = array_merge($aarr, $barr);
-                } else
-                    {
+                    $bpos = array_search($b, static::$js[$name]);
+                    if ($bpos === 0 || $bpos > 0) {
+                        $barr = array_slice(static::$js[$name], $bpos+1);
+                        $aarr = array_slice(static::$js[$name], 0, $bpos+1);
+                        array_push($aarr, $a);
+                        static::$js[$name] = array_merge($aarr, $barr);
+                    } else {
                         static::$js[$name][] = $a;
                     }
-            }
+                }
+                break;
         }
     }
 
@@ -366,7 +404,24 @@ class Asset
     }
 
 
-    /**
+	/**
+	 * Returns the full-path for an asset.
+	 *
+	 * @param  string  $source
+	 * @return string
+	 */
+	protected static function url($file)
+	{
+        if (preg_match('/(https?:)?\/\//i', $file)) {
+            return $file;
+        }
+        if (static::$domain == '/') {
+            return asset($file);
+        }
+        return rtrim(static::$domain, '/') .'/' . ltrim($file, '/');
+	}
+
+	/**
      * Loads all items from $css array not wrapped in <link> tags
      *
      * @param string $separator
@@ -377,18 +432,9 @@ class Asset
     {
         static::checkEnv();
 
-        if (!empty(static::$css))
-        {
-            foreach(static::$css as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                        $url = static::$domain . $file;
-                    }
-                echo static::$prefix . $url . $separator;
+        if (!empty(static::$css)) {
+            foreach(static::$css as $file) {
+                echo static::$prefix, self::url($file), $separator;
             }
         }
     }
@@ -402,18 +448,9 @@ class Asset
     {
         static::checkEnv();
 
-        if (!empty(static::$css))
-        {
-            foreach(static::$css as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                        $url = static::$domain . $file;
-                    }
-                echo static::$prefix . '<link rel="stylesheet" type="text/css" href="' . $url . '" />' . "\n";
+        if (!empty(static::$css)) {
+            foreach(static::$css as $file) {
+                echo static::$prefix, '<link rel="stylesheet" type="text/css" href="', self::url($file), "\" />\n";
             }
         }
     }
@@ -429,18 +466,9 @@ class Asset
     {
         static::checkEnv();
 
-        if (!empty(static::$less))
-        {
-            foreach(static::$less as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                        $url = static::$domain . $file;
-                    }
-                echo static::$prefix . $url . $separator;
+        if (!empty(static::$less)) {
+            foreach(static::$less as $file) {
+                echo static::$prefix, self::url($file), $separator;
             }
         }
     }
@@ -454,18 +482,9 @@ class Asset
     {
         static::checkEnv();
 
-        if (!empty(static::$less))
-        {
-            foreach(static::$less as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                        $url = static::$domain . $file;
-                    }
-                echo static::$prefix . '<link rel="stylesheet/less" type="text/css" href="' . $url . '" />' . "\n";
+        if (!empty(static::$less)) {
+            foreach(static::$less as $file) {
+                echo static::$prefix, '<link rel="stylesheet/less" type="text/css" href="', self::url($file), "\" />\n";
             }
         }
     }
@@ -480,25 +499,19 @@ class Asset
     */
     public static function styles($name = 'header')
     {
-        if (($name !== '') && (!empty(static::$styles[$name])))
-        {
-            $p = "\n" . static::$prefix . "<style type=\"text/css\">\n" . static::$prefix;
+        if (($name !== '') && (!empty(static::$styles[$name]))) {
+            echo "\n", static::$prefix, "<style type=\"text/css\">\n", static::$prefix;
             foreach(static::$styles[$name] as $style)
             {
-                $p .= $style . "\n" . static::$prefix;
+                echo "$style\n", static::$prefix;
             }
-            $p .= static::$prefix . "</style>\n";
-            echo $p;
-        }
-        else if (!empty(static::$styles))
-        {
-            $p = static::$prefix . "<style type=\"text/css\">\n";
-            foreach(static::$styles as $style)
-            {
-                $p .= $style . "\n";
+            echo static::$prefix, "</style>\n";
+        } else if (!empty(static::$styles)) {
+            echo static::$prefix, "<style type=\"text/css\">\n";
+            foreach(static::$styles as $style) {
+                echo "$style\n";
             }
-            $p .= "</style>\n";
-            echo $p;
+            echo "</style>\n";
         }
     }
 
@@ -515,21 +528,11 @@ class Asset
     {
         static::checkEnv();
 
-        if (!empty(static::$js[$name]))
-        {
-            foreach(static::$js[$name] as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                       $url = static::$domain . $file;
-                    }
-                echo static::$prefix . $url . $separator;
+        if (!empty(static::$js[$name])) {
+            foreach(static::$js[$name] as $file) {
+                echo static::$prefix, self::url($file), $separator;
             }
         }
-
     }
 
     /**
@@ -545,22 +548,14 @@ class Asset
     {
         static::checkEnv();
 
-        if ($name === false) $name = 'footer';
-        if (!empty(static::$js[$name]))
-        {
-            foreach(static::$js[$name] as $file)
-            {
-                if (preg_match('/(https?:)?\/\//i', $file))
-                {
-                    $url = $file;
-                } else
-                    {
-                       $url = static::$domain . $file;
-                    }
-                echo static::$prefix . '<script src="' . $url . '"></script>' . "\n";
+        if ($name === false) {
+            $name = 'footer';
+        }
+        if (!empty(static::$js[$name])) {
+            foreach(static::$js[$name] as $file) {
+                echo static::$prefix, '<script src="', self::url($file), "\"></script>\n";
             }
         }
-
     }
 
     /**
@@ -572,29 +567,20 @@ class Asset
     */
     public static function scripts($name = 'footer')
     {
-        if ($name == 'ready')
-        {
-            if (!empty(static::$scripts['ready']))
-            {
-                $p = static::$prefix . '<script>$(document).ready(function(){';
-                foreach(static::$scripts['ready'] as $script)
-                {
-                    $p .= $script . "\n" . static::$prefix;
+        if ($name == 'ready') {
+            if (!empty(static::$scripts['ready'])) {
+                echo static::$prefix, '<script>', (static::$useShortHandReady ? '$(' : '$(document).ready('), "function(){\n";
+                foreach(static::$scripts['ready'] as $script) {
+                    echo "$script\n", static::$prefix;
                 }
-                $p .= "});</script>\n";
-                echo $p;
+                echo "});</script>\n";
             }
-        } else
-            {
-                if (!empty(static::$scripts[$name]))
-                {
-                    foreach(static::$scripts[$name] as $script)
-                    {
-                        echo static::$prefix . '<script>' . $script . "</script>\n";
-                    }
+        } else {
+            if (!empty(static::$scripts[$name])) {
+                foreach(static::$scripts[$name] as $script) {
+                    echo static::$prefix, "<script>\n$script\n</script>\n";
                 }
             }
+        }
     }
-
-
 }


### PR DESCRIPTION
- Added support to googleapis (probed with Google Maps).
- Add an option to indicate what to do with "unrecognized" extensions, (ex. http://ecn.dev.virtualearth.net/MapControl/mapcontrol.ashx?v=6.3c), you can: do not add the asset, add the asset to css, add the asset to less or add the asset to js.
- Add a configuration option that indicate how to generate the JQuery ready event [short hand:$( or normal $(document).ready(].
- Now if static::#domain is '/' the helper function asset is used to generate the complete URL.
