### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-assets/security/code-scanning/1](https://github.com/RumenDamyanov/php-assets/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yml`. This block should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not modify them. If any step requires additional permissions (e.g., to create pull requests or write to issues), those can be added as needed. In this case, none of the steps require write access, so `contents: read` is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
